### PR TITLE
Remove custom request/response keys

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/logger "0.4.2"
+(defproject clanhr/logger "0.5.0"
   :description "Logging abstraction"
   :url "https://github.com/clanhr/logger"
   :dependencies [[org.clojure/clojure "1.7.0"]

--- a/src/clanhr/logger/middleware.clj
+++ b/src/clanhr/logger/middleware.clj
@@ -11,13 +11,19 @@
       (logger/generate-transaction-id (get-in context [:principal :account])
                                       (get-in context [:principal :user-id]))))
 
+(defn- log [data]
+  (-> data
+      (dissoc :compojure.api.middleware/options
+              :ring.swagger.middleware/data)
+      (logger/log)))
+
 (defn run
   "Logs requests"
   [handler service-name]
   (fn [context]
     (let [tid (get-tid context)]
-      (logger/log (merge context {:tid tid
-                                  :service-name (name service-name)}))
+      (log (merge context {:tid tid
+                           :service-name (name service-name)}))
       (let [response (handler (assoc context :tid tid))]
-        (logger/log response)
+        (log response)
         response))))


### PR DESCRIPTION
Swagger api adds all documentation to the request and that makes logging
very huge. This patch removes that keys.
